### PR TITLE
Fix GitHub Packages URLs and improve workflow error handling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,8 +28,9 @@ jobs:
 
       - name: Configure Poetry for GitHub Packages
         run: |
-          poetry config repositories.github https://maven.pkg.github.com/${{ github.repository }}
+          poetry config repositories.github https://pypi.pkg.github.com/${{ github.repository_owner }}/
           poetry config http-basic.github ${{ github.actor }} ${{ secrets.GITHUB_TOKEN }}
+          poetry config --list | grep github
 
       - name: Install dependencies
         run: |
@@ -38,10 +39,13 @@ jobs:
       - name: Build package
         run: |
           poetry build
+          ls -la dist/
 
       - name: Publish to GitHub Packages
+        env:
+          POETRY_PYPI_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          poetry publish --repository github
+          poetry publish --repository github --verbose
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/PUBLISHING_GUIDE.md
+++ b/PUBLISHING_GUIDE.md
@@ -36,7 +36,7 @@ This script will:
 
 1. **Configure the GitHub Packages repository**:
    ```bash
-   poetry config repositories.github https://maven.pkg.github.com/bhsh2002/dev-kit
+   poetry config repositories.github https://pypi.pkg.github.com/bhsh2002/
    ```
 
 2. **Configure authentication**:
@@ -93,13 +93,13 @@ You can also manually trigger the publishing workflow:
 Once published, others can install your package using:
 
 ```bash
-pip install --index-url https://pypi.org/simple/ --extra-index-url https://maven.pkg.github.com/bhsh2002/dev-kit dev-kit
+pip install --index-url https://pypi.org/simple/ --extra-index-url https://pypi.pkg.github.com/bhsh2002/ dev-kit
 ```
 
 Or if using Poetry in another project:
 
 ```bash
-poetry source add github https://maven.pkg.github.com/bhsh2002/dev-kit
+poetry source add github https://pypi.pkg.github.com/bhsh2002/
 poetry add dev-kit --source github
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ packages = [{include = "dev_kit", from = "src"}]
 
 [[tool.poetry.source]]
 name = "github"
-url = "https://maven.pkg.github.com/bhsh2002/dev-kit"
+url = "https://pypi.pkg.github.com/bhsh2002/"
 priority = "supplemental"
 
 [tool.poetry.urls]

--- a/setup_github_packages.sh
+++ b/setup_github_packages.sh
@@ -14,7 +14,7 @@ fi
 
 # Configure the GitHub Packages repository
 echo "Configuring GitHub Packages repository..."
-poetry config repositories.github https://maven.pkg.github.com/bhsh2002/dev-kit
+poetry config repositories.github https://pypi.pkg.github.com/bhsh2002/
 
 # Prompt for GitHub token
 echo ""


### PR DESCRIPTION
- Change from maven.pkg.github.com to pypi.pkg.github.com
- Add verbose logging and debugging to workflow
- Add environment variable for POETRY_PYPI_TOKEN_GITHUB
- Update all documentation with correct URLs