### PR TITLE
Fix github packages publish 404 error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ packages = [{include = "dev_kit", from = "src"}]
 
 [[tool.poetry.source]]
 name = "github"
-url = "https://pypi.pkg.github.com/bhsh2002"
+url = "https://pypi.pkg.github.com/bhsh2002/"
 priority = "supplemental"
 
 [tool.poetry.urls]

--- a/setup_github_packages.sh
+++ b/setup_github_packages.sh
@@ -14,7 +14,7 @@ fi
 
 # Configure the GitHub Packages repository
 echo "Configuring GitHub Packages repository..."
-poetry config repositories.github https://pypi.pkg.github.com/bhsh2002
+poetry config repositories.github https://pypi.pkg.github.com/bhsh2002/
 
 # Prompt for GitHub token
 echo ""


### PR DESCRIPTION
Add trailing slash to GitHub Packages repository URLs to resolve 404 publishing error.

---
<a href="https://cursor.com/background-agent?bcId=bc-3603bed4-6d6f-46a6-a679-cfe876923e28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3603bed4-6d6f-46a6-a679-cfe876923e28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

